### PR TITLE
Fix spanish name for ampersand

### DIFF
--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -19,7 +19,7 @@
     "$": ["dólar", "símbolo del dólar"],
     "%": ["porcentaje"],
     "^": ["acento circunflejo"],
-    "&": ["ampersand"],
+    "&": ["et"],
     "*": ["asterisco"],
     "-": ["guión"],
     "_": ["guión bajo", "barra baja"],


### PR DESCRIPTION
Being a bit pedantic:
> El carácter &, llamado "et" o a veces "y comercial", es una ligadura de la conjunción copulativa latina «et».

https://es.wikipedia.org/wiki/%26

https://www.rae.es/dpd/ayuda/simbolos-o-signos-no-alfabetizables

